### PR TITLE
Add AI Weekly to newsletter/resource list

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Suggestions and contributions are always welcome; make sure you read the [contri
   - [Website](#website)
   - [Writing / Blogging](#writing)
 
+- [AI Weekly](https://aiweekly.co) - Curated AI intelligence briefing from industry leaders covering models, funding, policy, and applications. 3x/week since 2017, 40K+ subscribers.
 <a name="ab"></a>
 # A/B Tests & Growth Hacking
 - Petit Hacks: Acquisition, retention, & revenue hacks used by companies.


### PR DESCRIPTION
Adding [AI Weekly](https://aiweekly.co) — curated AI intelligence briefing from industry leaders. 3x/week since 2017, 40K+ subscribers covering models, funding, policy, and real-world applications.

Featured on Machine Learning Mastery and multiple 'best AI newsletters' roundups.